### PR TITLE
mui base 컴포넌트 구현 및 스타일 네임스페이스 구체화

### DIFF
--- a/src/components/CustomAppBar/index.tsx
+++ b/src/components/CustomAppBar/index.tsx
@@ -1,0 +1,17 @@
+import { AppBar as MuiAppBar } from '@mui/material';
+
+type MUIAppBarProps = React.ComponentProps<typeof MuiAppBar>;
+
+type CustomAppBarProps = MUIAppBarProps & {
+  children: React.ReactNode;
+};
+
+const CustomAppBar = ({ children, ...rest }: CustomAppBarProps) => {
+  return (
+    <MuiAppBar color='inherit' elevation={0} {...rest}>
+      {children}
+    </MuiAppBar>
+  );
+};
+
+export default CustomAppBar;

--- a/src/components/CustomTextField/index.tsx
+++ b/src/components/CustomTextField/index.tsx
@@ -1,0 +1,31 @@
+import { TextField as MuiTextFiled } from '@mui/material';
+import styled from '@emotion/styled';
+
+type MuiTextFiledProps = React.ComponentProps<typeof MuiTextFiled>;
+
+const CustomTextField = ({ ...rest }: MuiTextFiledProps) => {
+  return <TextFiledBase {...rest} />;
+};
+
+export default CustomTextField;
+
+const TextFiledBase = styled(MuiTextFiled)`
+  & .MuiFilledInput-root {
+    background-color: ${({ theme }) => theme.colors.blueGrey.A06};
+
+    &.MuiInputBase-root::before {
+      border-bottom-color: ${({ theme }) => theme.colors.blueGrey.A42};
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background-color: ${({ theme }) => theme.colors.blueGrey.A09};
+      }
+    }
+  }
+
+  & input {
+    padding: 6px 36px 6px 12px;
+    color: ${({ theme }) => theme.colors.text.primary};
+  }
+`;

--- a/src/components/CustomToolBar/index.tsx
+++ b/src/components/CustomToolBar/index.tsx
@@ -1,0 +1,18 @@
+import { Toolbar as MuiToolbar } from '@mui/material';
+import styled from '@emotion/styled';
+
+type MUIToolbarProps = React.ComponentProps<typeof MuiToolbar>;
+
+type CustomToolbarProps = MUIToolbarProps & {
+  children: React.ReactNode;
+};
+
+const CustomToolbar = ({ children }: CustomToolbarProps) => {
+  return <ToolbarBase>{children}</ToolbarBase>;
+};
+
+export default CustomToolbar;
+
+const ToolbarBase = styled(MuiToolbar)`
+  padding: 8px 16px;
+`;

--- a/src/pages/Home/components/RegionButton.style.ts
+++ b/src/pages/Home/components/RegionButton.style.ts
@@ -11,3 +11,7 @@ export const LocationChip = styled(Chip)`
     padding-left: 8px;
   }
 `;
+
+export const C = { LocationChip };
+
+export const S = { Button };

--- a/src/pages/Home/components/RegionButton.tsx
+++ b/src/pages/Home/components/RegionButton.tsx
@@ -1,7 +1,7 @@
 import LocationIcon from '@/components/icon/Location';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import * as S from './RegionButton.style';
+import { C, S } from './RegionButton.style';
 
 type LocationButtonProps = {
   region: string;
@@ -37,7 +37,7 @@ const RegionButton = ({
 
   return (
     <S.Button onPointerUp={handlePointerUp} onPointerDown={handlePointerDown}>
-      <S.LocationChip
+      <C.LocationChip
         label={region}
         variant={isSelected ? 'filled' : 'outlined'}
         icon={isSelected ? <LocationIcon /> : undefined}

--- a/src/pages/Home/components/RegionSelector.style.ts
+++ b/src/pages/Home/components/RegionSelector.style.ts
@@ -1,9 +1,9 @@
 import forwardPropOption from '@/utils/emotionForwardPropOption';
 import styled from '@emotion/styled';
 import { Chip, css } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link as LinkBase } from 'react-router-dom';
 
-export const Section = styled.section`
+const Section = styled.section`
   position: relative;
   display: flex;
   gap: 8px;
@@ -21,7 +21,7 @@ export const Section = styled.section`
   -ms-overflow-style: none;
 `;
 
-export const LinkWrap = styled(Link, forwardPropOption)<{
+const Link = styled(LinkBase, forwardPropOption)<{
   $isScrollActive: boolean;
 }>`
   position: sticky;
@@ -60,7 +60,7 @@ export const LinkWrap = styled(Link, forwardPropOption)<{
   }
 `;
 
-export const PlusChip = styled(Chip)`
+const PlusChip = styled(Chip)`
   position: relative;
   width: 32px;
   height: 32px;
@@ -72,3 +72,12 @@ export const PlusChip = styled(Chip)`
     justify-content: center;
   }
 `;
+
+export const C = {
+  Link,
+  PlusChip,
+};
+
+export const S = {
+  Section,
+};

--- a/src/pages/Home/components/RegionSelector.tsx
+++ b/src/pages/Home/components/RegionSelector.tsx
@@ -1,7 +1,7 @@
 import PlusIcon from '@/components/icon/Plus';
 import RegionButton from './RegionButton';
 import { Region } from '@/types/region';
-import * as S from './RegionSelector.style';
+import { C, S } from './RegionSelector.style';
 import { useEffect, useRef, useState } from 'react';
 
 type LocationSelectorProps = {
@@ -32,9 +32,9 @@ const RegionSelector = ({ regions, onRegionClick }: LocationSelectorProps) => {
         />
       ))}
 
-      <S.LinkWrap to={'/search'} $isScrollActive={isScrollActive}>
-        <S.PlusChip variant='outlined' label={<PlusIcon />} />
-      </S.LinkWrap>
+      <C.Link to={'/search'} $isScrollActive={isScrollActive}>
+        <C.PlusChip variant='outlined' label={<PlusIcon />} />
+      </C.Link>
     </S.Section>
   );
 };

--- a/src/pages/Search/components/RegionItem.style.ts
+++ b/src/pages/Search/components/RegionItem.style.ts
@@ -15,3 +15,7 @@ export const Item = styled(ListItem)`
     color: #2077af;
   }
 `;
+
+export const C = {
+  Item,
+};

--- a/src/pages/Search/components/RegionItem.tsx
+++ b/src/pages/Search/components/RegionItem.tsx
@@ -1,5 +1,5 @@
 import CheckIcon from '@/components/icon/Check';
-import * as S from './RegionItem.style';
+import { C } from './RegionItem.style';
 import { IconButton } from '@mui/material';
 import { MY_REGIONS } from '@/constants/localStorage/key';
 import { Region } from '@/types/region';
@@ -38,7 +38,7 @@ const RegionItem = ({
   };
 
   return (
-    <S.Item divider onClick={handleSaveClick}>
+    <C.Item divider onClick={handleSaveClick}>
       <span>
         {before}
         <strong>{match}</strong>
@@ -48,7 +48,7 @@ const RegionItem = ({
       <IconButton>
         <CheckIcon />
       </IconButton>
-    </S.Item>
+    </C.Item>
   );
 };
 

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -1,14 +1,16 @@
 import ArrowIcon from '@/components/icon/Arrow';
-import { Button, Toolbar } from '@mui/material';
+import { Button } from '@mui/material';
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import regions from '@/assets/region.json';
 import RegionItem from './components/RegionItem';
 import CancelIcon from '@/components/icon/Cancel';
-import * as S from './style';
+import { C, S } from './style';
 import { Region } from '@/types/region';
 import { MY_REGIONS } from '@/constants/localStorage/key';
 import TrashCan from '@/components/icon/TrashCan';
+import CustomToolbar from '@/components/CustomToolBar';
+import CustomTextField from '@/components/CustomTextField';
 
 type SearchLocationState = {
   state?: {
@@ -53,16 +55,16 @@ const Search = () => {
 
   return (
     <>
-      <S.Header color='inherit' elevation={0}>
-        <Toolbar>
+      <C.AppBar>
+        <CustomToolbar>
           <Link to={'/'}>
-            <S.GoBackButton size='large'>
+            <C.GoBackButton size='large'>
               <ArrowIcon />
-            </S.GoBackButton>
+            </C.GoBackButton>
           </Link>
 
           <S.InputWrapper>
-            <S.Input
+            <CustomTextField
               variant='filled'
               value={keyword}
               onChange={handleChange}
@@ -75,10 +77,10 @@ const Search = () => {
               </S.CancleButton>
             )}
           </S.InputWrapper>
-        </Toolbar>
-      </S.Header>
+        </CustomToolbar>
+      </C.AppBar>
 
-      <S.RegionList>
+      <C.RegionList>
         {matchItems.map((item) => (
           <RegionItem
             key={item.region}
@@ -88,7 +90,7 @@ const Search = () => {
             {...item}
           />
         ))}
-      </S.RegionList>
+      </C.RegionList>
 
       {matchItems.length === 1 && isSaved && (
         <S.Aside>

--- a/src/pages/Search/style.ts
+++ b/src/pages/Search/style.ts
@@ -11,16 +11,16 @@ const AppBar = styled(CustomAppBar)`
   transform: translateX(-50%);
 `;
 
-export const GoBackButton = styled(IconButton)`
+const GoBackButton = styled(IconButton)`
   margin-right: 16px;
 `;
 
-export const InputWrapper = styled.div`
+const InputWrapper = styled.div`
   position: relative;
   width: 100%;
 `;
 
-export const CancleButton = styled.button`
+const CancleButton = styled.button`
   position: absolute;
   top: 50%;
   right: 12px;
@@ -34,7 +34,7 @@ export const CancleButton = styled.button`
   transform: translateY(-50%);
 `;
 
-export const RegionList = styled(List)`
+const RegionList = styled(List)`
   padding: 0;
   margin-top: 56px;
 
@@ -43,7 +43,7 @@ export const RegionList = styled(List)`
   }
 `;
 
-export const Aside = styled.aside`
+const Aside = styled.aside`
   position: absolute;
   bottom: 0;
   left: 0;

--- a/src/pages/Search/style.ts
+++ b/src/pages/Search/style.ts
@@ -1,12 +1,13 @@
+import CustomAppBar from '@/components/CustomAppBar';
 import styled from '@emotion/styled';
-import { AppBar, IconButton, List, TextField } from '@mui/material';
+import { IconButton, List } from '@mui/material';
 
-export const Header = styled(AppBar)`
+const AppBar = styled(CustomAppBar)`
   position: fixed;
   top: 0;
   left: 50%;
   max-width: 768px;
-  border-bottom: 1px solid #b2becc;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.blueGrey[300]};
   transform: translateX(-50%);
 `;
 
@@ -17,17 +18,6 @@ export const GoBackButton = styled(IconButton)`
 export const InputWrapper = styled.div`
   position: relative;
   width: 100%;
-`;
-
-export const Input = styled(TextField)`
-  & .MuiInputBase-root::before {
-    border-bottom-color: ${({ theme }) => theme.colors.blueGrey.A42};
-  }
-
-  & input {
-    padding: 6px 36px 6px 12px;
-    color: ${({ theme }) => theme.colors.text.primary};
-  }
 `;
 
 export const CancleButton = styled.button`
@@ -66,3 +56,15 @@ export const Aside = styled.aside`
     margin-right: 13px;
   }
 `;
+
+export const S = {
+  InputWrapper,
+  CancleButton,
+  Aside,
+};
+
+export const C = {
+  AppBar,
+  GoBackButton,
+  RegionList,
+};


### PR DESCRIPTION
## 📄 Summary
- mui base 컴포넌트 구현
- 스타일 네임스페이스 구체화

## 🙋🏻 More
### - mui base 컴포넌트
![image](https://github.com/user-attachments/assets/914e0bd6-f168-45b1-b0cb-cf57acb8c52d)

Mui 컴포넌트 중 custom된 공통 스타일이 있는 경우 custom 컴포넌트로 구현해봤습니다.

backdrop, tooltip 등등은 아직 만들지 않았습니다. 조금 더 디자인이 확정되면 만들어도 될 것 같습니다!

### - 네임스페이스 구체화
- 기존 
  - <S.컴포넌트 /> 단일

- 변경
  - 일반 태그: <S. 컴포넌트 /> → `styled.div` 
  - 컴포넌트 재정의: <C. 컴포넌트 /> → `styled(컴포넌트)`

