### PR TITLE
최근 검색어 조회/등록/삭제 구현

### DIFF
--- a/src/pages/Search/components/RecentSearch.tsx
+++ b/src/pages/Search/components/RecentSearch.tsx
@@ -18,7 +18,7 @@ const RecentSearchList = () => {
       <C.RecentList>
         {data.map((search) => (
           <C.Item divider key={`${search.city} ${search.district}`}>
-            ${search.city} ${search.district}
+            {search.city} {search.district}
             <IconButton>
               <CloseIcon />
             </IconButton>

--- a/src/pages/Search/components/RecentSearch.tsx
+++ b/src/pages/Search/components/RecentSearch.tsx
@@ -1,25 +1,40 @@
 import { IconButton } from '@mui/material';
 import { C } from './RecentSearchList.style';
 import CloseIcon from '@/components/icon/Close';
-import { useQuery } from '@tanstack/react-query';
-import { getRecentSearch } from '@/service/search';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deleteSearchWord, getRecentSearch } from '@/service/search';
 import { GUEST_UUID } from '@/constants/localStorage/key';
 
 const RecentSearchList = () => {
+  const queryClient = useQueryClient();
   const { data } = useQuery({
     queryKey: ['recentSearch', localStorage.getItem(GUEST_UUID)],
     queryFn: getRecentSearch,
     retry: 1,
   });
 
+  const { mutate } = useMutation({
+    mutationFn: deleteSearchWord,
+  });
+
+  const handleDeleteClick = (city: string, district: string) => () => {
+    mutate(
+      { city, district },
+      {
+        onSuccess: () =>
+          queryClient.invalidateQueries({ queryKey: ['recentSearch'] }),
+      }
+    );
+  };
+
   if (!data) return;
   return (
     <section>
       <C.RecentList>
-        {data.map((search) => (
-          <C.Item divider key={`${search.city} ${search.district}`}>
-            {search.city} {search.district}
-            <IconButton>
+        {data.map(({ city, district }) => (
+          <C.Item divider key={`${city} ${district}`}>
+            {city} {district}
+            <IconButton onClick={handleDeleteClick(city, district)}>
               <CloseIcon />
             </IconButton>
           </C.Item>

--- a/src/pages/Search/components/RecentSearch.tsx
+++ b/src/pages/Search/components/RecentSearch.tsx
@@ -4,35 +4,60 @@ import CloseIcon from '@/components/icon/Close';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteSearchWord, getRecentSearch } from '@/service/search';
 import { GUEST_UUID } from '@/constants/localStorage/key';
+import useAppDispatch from '@/hooks/useAppDispatch';
+import { currentRegionActions } from '@/redux/slice/currentRegionSlice';
+import { Region } from '@/types/region';
+import { useNavigate } from 'react-router-dom';
 
-const RecentSearchList = () => {
-  const queryClient = useQueryClient();
+type RecentSearchListProps = {
+  regions: Region[];
+};
+
+const RecentSearchList = ({ regions }: RecentSearchListProps) => {
   const { data } = useQuery({
     queryKey: ['recentSearch', localStorage.getItem(GUEST_UUID)],
     queryFn: getRecentSearch,
     retry: 1,
   });
-
   const { mutate } = useMutation({
     mutationFn: deleteSearchWord,
   });
+  const queryClient = useQueryClient();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
-  const handleDeleteClick = (city: string, district: string) => () => {
-    mutate(
-      { city, district },
-      {
-        onSuccess: () =>
-          queryClient.invalidateQueries({ queryKey: ['recentSearch'] }),
-      }
+  const handleRegionClick = (city: string, district: string) => () => {
+    const region = regions.find(
+      (region) => region.region === `${city} ${district}`
     );
+    if (region) {
+      dispatch(currentRegionActions.setCurrentRegion(region));
+      navigate('/');
+    }
   };
+
+  const handleDeleteClick =
+    (city: string, district: string) => (e: React.MouseEvent) => {
+      e.stopPropagation();
+      mutate(
+        { city, district },
+        {
+          onSuccess: () =>
+            queryClient.invalidateQueries({ queryKey: ['recentSearch'] }),
+        }
+      );
+    };
 
   if (!data) return;
   return (
     <section>
       <C.RecentList>
         {data.map(({ city, district }) => (
-          <C.Item divider key={`${city} ${district}`}>
+          <C.Item
+            divider
+            key={`${city} ${district}`}
+            onClick={handleRegionClick(city, district)}
+          >
             {city} {district}
             <IconButton onClick={handleDeleteClick(city, district)}>
               <CloseIcon />

--- a/src/pages/Search/components/RecentSearch.tsx
+++ b/src/pages/Search/components/RecentSearch.tsx
@@ -1,29 +1,29 @@
 import { IconButton } from '@mui/material';
 import { C } from './RecentSearchList.style';
 import CloseIcon from '@/components/icon/Close';
+import { useQuery } from '@tanstack/react-query';
+import { getRecentSearch } from '@/service/search';
+import { GUEST_UUID } from '@/constants/localStorage/key';
 
 const RecentSearchList = () => {
+  const { data } = useQuery({
+    queryKey: ['recentSearch', localStorage.getItem(GUEST_UUID)],
+    queryFn: getRecentSearch,
+    retry: 1,
+  });
+
+  if (!data) return;
   return (
     <section>
       <C.RecentList>
-        <C.Item divider>
-          서울특별시 강서구
-          <IconButton>
-            <CloseIcon />
-          </IconButton>
-        </C.Item>
-        <C.Item divider>
-          서울특별시 강서구
-          <IconButton>
-            <CloseIcon />
-          </IconButton>
-        </C.Item>
-        <C.Item divider>
-          서울특별시 강서구
-          <IconButton>
-            <CloseIcon />
-          </IconButton>
-        </C.Item>
+        {data.map((search) => (
+          <C.Item divider key={`${search.city} ${search.district}`}>
+            ${search.city} ${search.district}
+            <IconButton>
+              <CloseIcon />
+            </IconButton>
+          </C.Item>
+        ))}
       </C.RecentList>
     </section>
   );

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -33,7 +33,7 @@ const Search = () => {
 
       <RegionSetButton />
 
-      {!keyword && <RecentSearchList />}
+      {!keyword && <RecentSearchList regions={regions} />}
 
       <C.RegionList>
         {matchItems.map((item) => (

--- a/src/service/search.ts
+++ b/src/service/search.ts
@@ -55,3 +55,33 @@ export async function registerSearchWord(region: string) {
     throw new Error(error as string);
   }
 }
+
+type RegionName = {
+  city: string;
+  district: string;
+};
+export async function deleteSearchWord({ city, district }: RegionName) {
+  try {
+    const uuid = localStorage.getItem(GUEST_UUID);
+    const res = await fetch(
+      `${import.meta.env.VITE_SERVER_URL}/search/${uuid}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ city, district }),
+      }
+    );
+
+    const json = await res.json();
+
+    if (!res.ok) {
+      throw new Error(`${json.code}: ${json.message}`);
+    }
+
+    return json;
+  } catch (error) {
+    throw new Error(error as string);
+  }
+}

--- a/src/service/search.ts
+++ b/src/service/search.ts
@@ -1,0 +1,30 @@
+import { GUEST_UUID } from '@/constants/localStorage/key';
+import { RecentSearchData, ResponseBase } from '@/types/search';
+import { guestLogin } from './login';
+
+export async function getRecentSearch(): Promise<RecentSearchData> {
+  try {
+    const uuid = localStorage.getItem(GUEST_UUID);
+
+    const res = await fetch(
+      `${import.meta.env.VITE_SERVER_URL}/search/${uuid}`
+    );
+    const json: ResponseBase<RecentSearchData> = await res.json();
+
+    if (!res.ok) {
+      // 유효하지 않은 uuid인 경우, 새로운 uuid 발급
+      if (json.code === 'S002') {
+        const data = await guestLogin();
+        if (data.data.uuid) {
+          localStorage.setItem(GUEST_UUID, data.data.uuid);
+        }
+      }
+
+      throw new Error(`${json.code}: ${json.message}`);
+    }
+
+    return json.data;
+  } catch (error) {
+    throw new Error(error as string);
+  }
+}

--- a/src/service/search.ts
+++ b/src/service/search.ts
@@ -28,3 +28,30 @@ export async function getRecentSearch(): Promise<RecentSearchData> {
     throw new Error(error as string);
   }
 }
+
+export async function registerSearchWord(region: string) {
+  try {
+    const uuid = localStorage.getItem(GUEST_UUID);
+    const [city, district] = region.split(' ');
+    const res = await fetch(
+      `${import.meta.env.VITE_SERVER_URL}/search/${uuid}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ city, district }),
+      }
+    );
+
+    const json = await res.json();
+
+    if (!res.ok) {
+      throw new Error(`${json.code}: ${json.message}`);
+    }
+
+    return json;
+  } catch (error) {
+    throw new Error(error as string);
+  }
+}

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,11 @@
+export type ResponseBase<T> = {
+  data: T;
+  message: string;
+  status: number;
+  code: string;
+};
+
+export type RecentSearchData = Array<{
+  city: string;
+  district: string;
+}>;


### PR DESCRIPTION
## 📄 Summary
- 최근 검색어 조회/등록/삭제 구현
- 최근 검색어 클릭 시, 해당 지역으로 사용자 위치 설정

## 🙋🏻 More
data.data.some으로 접근하지 않고 바로 data.some으로 접근할 수 있게 search service에만 type을 새로 정의해봤습니다. 어떤 방식이 더 좋을지 고민해보고 전체적으로 적용해볼까합니다.


```ts
// 기존: data.data.map(() => ...)
  const { data } = useQuery({
    queryKey: [''],
    queryFn: getRecentSearch
  });

  return (
     {data.map(() => ...)}
  )
```

```ts
export async function getRecentSearch(): Promise<RecentSearchData> {
  try {
    const res = await fetch();
    const json: ResponseBase<RecentSearchData> = await res.json();

    ...

    return json.data; // data만 return
  } catch (error) {
    throw new Error(error as string);
  }
}
```

```ts
export type ResponseBase<T> = {
  data: T;
  message: string;
  status: number;
  code: string;
};

export type RecentSearchData = Array<{
  city: string;
  district: string;
}>;

```